### PR TITLE
エラーメッセージの日本語化機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem "image_processing", "~> 1.2"
 gem "payjp"
 
 gem "aws-sdk-s3", require: false
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -329,6 +332,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails
   rubocop

--- a/app/forms/item_order.rb
+++ b/app/forms/item_order.rb
@@ -7,7 +7,7 @@ class ItemOrder
     validates :prefecture_id, numericality: { other_than: 1, message: 'を選択してください' }
     validates :city
     validates :addresses
-    validates :phone_number, format: { with: /\A\d{,11}\z/ }
+    validates :phone_number, format: { with: /\A\d{,11}\z/, message: 'を正しく入力してください' }
     validates :user_id
     validates :item_id
     validates :token

--- a/app/forms/item_order.rb
+++ b/app/forms/item_order.rb
@@ -3,8 +3,8 @@ class ItemOrder
   attr_accessor :postal_code, :prefecture_id, :city, :addresses, :building, :phone_number, :user_id, :item_id, :token
 
   with_options presence: true do
-    validates :postal_code,   format: { with: /\A\d{3}[-]\d{4}\z/ }
-    validates :prefecture_id, numericality: { other_than: 1, message: 'Select' }
+    validates :postal_code,   format: { with: /\A\d{3}[-]\d{4}\z/, message: 'を正しく入力してください' }
+    validates :prefecture_id, numericality: { other_than: 1, message: 'を選択してください' }
     validates :city
     validates :addresses
     validates :phone_number, format: { with: /\A\d{,11}\z/ }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,8 +10,8 @@ class Item < ApplicationRecord
   has_one                :order
   has_many               :comments, dependent: :destroy
 
+  validates :image, presence: { message: 'を選択してください' }
   with_options presence: true do
-    validates :image
     validates :name
     validates :info
     validates :category
@@ -21,7 +21,7 @@ class Item < ApplicationRecord
     validates :scheduled_delivery
   end
 
-  with_options numericality: { other_than: 1, message: 'Select' } do
+  with_options numericality: { other_than: 1, message: 'を選択してください' } do
     validates :category_id
     validates :sales_status_id
     validates :shipping_fee_status_id
@@ -30,6 +30,6 @@ class Item < ApplicationRecord
   end
 
   validates :price, presence: true
-  validates :price, numericality: { message: 'must be Half-width number' }
-  validates :price, inclusion: { in: 300..9_999_999, message: 'is Out of setting range' }
+  validates :price, numericality: { message: 'は半角数字で入力してください' }
+  validates :price, inclusion: { in: 300..9_999_999, message: 'は ¥300〜¥9,999,999の間に設定してください' }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,13 @@ class User < ApplicationRecord
   birthday = /\A\d{4}-\d{2}-\d{2}\z/
   with_options presence: true do
     validates :nickname
-    validates :first_name,      format: { with: zenkaku }
-    validates :last_name,       format: { with: zenkaku }
-    validates :first_name_kana, format: { with: zenkaku_kana }
-    validates :last_name_kana,  format: { with: zenkaku_kana }
+    validates :first_name,      format: { with: zenkaku, message: 'は全角で入力してください' }
+    validates :last_name,       format: { with: zenkaku, message: 'は全角で入力してください' }
+    validates :first_name_kana, format: { with: zenkaku_kana, message: 'は全角（カナ）で入力してください' }
+    validates :last_name_kana,  format: { with: zenkaku_kana, message: 'は全角（カナ）で入力してください' }
     validates :birth_date,      format: { with: birthday }
   end
-  validates :password, format: { with: eng_num }
+  validates :password, format: { with: eng_num, message: 'は英数字混合で入力してください' }
 
   has_many :items
   has_many :orders

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,142 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -9,7 +9,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,12 @@ ja:
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        first_name: 名前
+        last_name: 名字
+        first_name_kana: 名前（カナ）
+        last_name_kana: 名字（カナ）
+        birth_date: 生年月日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,4 +27,7 @@ ja:
         scheduled_delivery_id: 発送までの日数
         price: 販売価格
         user: ユーザー
-  
+      comment:
+        text: コメント
+        user: ユーザー
+        item: 商品

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,3 +31,18 @@ ja:
         text: コメント
         user: ユーザー
         item: 商品
+  activemodel:
+    attributes:
+      item_order:
+        postal_code: 郵便番号
+        prefecture: 都道府県
+        prefecture_id: 都道府県
+        city: 市区町村
+        addresses: 番地
+        building: 建物名
+        phone_number: 電話番号
+        user_id: ユーザー
+        item_id: 商品
+        token: クレジットカード情報
+
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,3 +11,20 @@ ja:
         first_name_kana: 名前（カナ）
         last_name_kana: 名字（カナ）
         birth_date: 生年月日
+      item:
+        image: 画像
+        name: 商品名
+        info: 商品の説明
+        category: カテゴリー
+        category_id: カテゴリー
+        sales_status: 商品の状態
+        sales_status_id: 商品の状態
+        shipping_fee_status: 配送料の負担
+        shipping_fee_status_id: 配送料の負担
+        prefecture: 発送元の地域
+        prefecture_id: 発送元の地域
+        scheduled_delivery: 発送までの日数
+        scheduled_delivery_id: 発送までの日数
+        price: 販売価格
+        user: ユーザー
+  

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Comment, type: :model do
       @comment.text = nil
       @comment.valid?
       # expect(@comment.errors.full_messages).to include("Text can't be blank")
-      expect(@comment.errors.full_messages).to include("コメントを入力してください")
+      expect(@comment.errors.full_messages).to include('コメントを入力してください')
     end
 
     it 'textが101文字以上だと保存できない' do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -13,25 +13,26 @@ RSpec.describe Comment, type: :model do
     it 'textが空だと保存できない' do
       @comment.text = nil
       @comment.valid?
-      expect(@comment.errors.full_messages).to include("Text can't be blank")
+      # expect(@comment.errors.full_messages).to include("Text can't be blank")
+      expect(@comment.errors.full_messages).to include("コメントを入力してください")
     end
 
     it 'textが101文字以上だと保存できない' do
       @comment.text = Faker::Lorem.characters(number: 101)
       @comment.valid?
-      expect(@comment.errors.full_messages).to include('Text is too long (maximum is 100 characters)')
+      expect(@comment.errors.full_messages).to include('コメントは100文字以内で入力してください')
     end
 
     it 'userが紐づいていなければ保存できない' do
       @comment.user = nil
       @comment.valid?
-      expect(@comment.errors.full_messages).to include('User must exist')
+      expect(@comment.errors.full_messages).to include('ユーザーを入力してください')
     end
 
     it 'itemが紐づいていなければ保存できない' do
       @comment.item = nil
       @comment.valid?
-      expect(@comment.errors.full_messages).to include('Item must exist')
+      expect(@comment.errors.full_messages).to include('商品を入力してください')
     end
   end
 end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ItemOrder, type: :model do
       @order.postal_code = nil
       @order.valid?
       # expect(@order.errors.full_messages).to include("Postal code can't be blank")
-      expect(@order.errors.full_messages).to include("郵便番号を入力してください")
+      expect(@order.errors.full_messages).to include('郵便番号を入力してください')
     end
 
     it 'postal_codeは[***-****]の形でないと保存できない' do
@@ -40,7 +40,7 @@ RSpec.describe ItemOrder, type: :model do
       @order.prefecture_id = nil
       @order.valid?
       # expect(@order.errors.full_messages).to include("Prefecture can't be blank")
-      expect(@order.errors.full_messages).to include("都道府県を入力してください")
+      expect(@order.errors.full_messages).to include('都道府県を入力してください')
     end
 
     it 'prefecture_idが選択されないと保存できない' do
@@ -54,19 +54,19 @@ RSpec.describe ItemOrder, type: :model do
       @order.city = nil
       @order.valid?
       # expect(@order.errors.full_messages).to include("City can't be blank")
-      expect(@order.errors.full_messages).to include("市区町村を入力してください")
+      expect(@order.errors.full_messages).to include('市区町村を入力してください')
     end
 
     it 'addressesが空だと保存できない' do
       @order.addresses = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("番地を入力してください")
+      expect(@order.errors.full_messages).to include('番地を入力してください')
     end
 
     it 'phone_numberが空だと保存できない' do
       @order.phone_number = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("電話番号を入力してください")
+      expect(@order.errors.full_messages).to include('電話番号を入力してください')
     end
 
     it 'phone_numberが12桁以上だと保存できない' do
@@ -84,19 +84,19 @@ RSpec.describe ItemOrder, type: :model do
     it 'user_idが空だと保存できない' do
       @order.user_id = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("ユーザーを入力してください")
+      expect(@order.errors.full_messages).to include('ユーザーを入力してください')
     end
 
     it 'item_idが空だと保存できない' do
       @order.item_id = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("商品を入力してください")
+      expect(@order.errors.full_messages).to include('商品を入力してください')
     end
 
     it 'tokenが空だと保存できない' do
       @order.token = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("クレジットカード情報を入力してください")
+      expect(@order.errors.full_messages).to include('クレジットカード情報を入力してください')
     end
   end
 end

--- a/spec/models/item_order_spec.rb
+++ b/spec/models/item_order_spec.rb
@@ -18,79 +18,85 @@ RSpec.describe ItemOrder, type: :model do
     it 'postal_codeが空だと保存できない' do
       @order.postal_code = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("Postal code can't be blank")
+      # expect(@order.errors.full_messages).to include("Postal code can't be blank")
+      expect(@order.errors.full_messages).to include("郵便番号を入力してください")
     end
 
     it 'postal_codeは[***-****]の形でないと保存できない' do
       @order.postal_code = '1234567'
       @order.valid?
-      expect(@order.errors.full_messages).to include('Postal code is invalid')
+      # expect(@order.errors.full_messages).to include('Postal code is invalid')
+      expect(@order.errors.full_messages).to include('郵便番号を正しく入力してください')
     end
 
     it 'postal_codeが全角数字で入力されると保存できない' do
       @order.postal_code = '１２３-２３４５'
       @order.valid?
-      expect(@order.errors.full_messages).to include('Postal code is invalid')
+      # expect(@order.errors.full_messages).to include('Postal code is invalid')
+      expect(@order.errors.full_messages).to include('郵便番号を正しく入力してください')
     end
 
     it 'prefecture_idが空だと保存できない' do
       @order.prefecture_id = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("Prefecture can't be blank")
+      # expect(@order.errors.full_messages).to include("Prefecture can't be blank")
+      expect(@order.errors.full_messages).to include("都道府県を入力してください")
     end
 
     it 'prefecture_idが選択されないと保存できない' do
       @order.prefecture_id = 1
       @order.valid?
-      expect(@order.errors.full_messages).to include('Prefecture Select')
+      # expect(@order.errors.full_messages).to include('Prefecture Select')
+      expect(@order.errors.full_messages).to include('都道府県を選択してください')
     end
 
     it 'cityが空だと保存できない' do
       @order.city = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("City can't be blank")
+      # expect(@order.errors.full_messages).to include("City can't be blank")
+      expect(@order.errors.full_messages).to include("市区町村を入力してください")
     end
 
     it 'addressesが空だと保存できない' do
       @order.addresses = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("Addresses can't be blank")
+      expect(@order.errors.full_messages).to include("番地を入力してください")
     end
 
     it 'phone_numberが空だと保存できない' do
       @order.phone_number = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("Phone number can't be blank")
+      expect(@order.errors.full_messages).to include("電話番号を入力してください")
     end
 
     it 'phone_numberが12桁以上だと保存できない' do
       @order.phone_number = '123456789012'
       @order.valid?
-      expect(@order.errors.full_messages).to include('Phone number is invalid')
+      expect(@order.errors.full_messages).to include('電話番号を正しく入力してください')
     end
 
     it 'phone_numberが全角数字で入力されると保存できない' do
       @order.phone_number = '１２３４５６７８９０１'
       @order.valid?
-      expect(@order.errors.full_messages).to include('Phone number is invalid')
+      expect(@order.errors.full_messages).to include('電話番号を正しく入力してください')
     end
 
     it 'user_idが空だと保存できない' do
       @order.user_id = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("User can't be blank")
+      expect(@order.errors.full_messages).to include("ユーザーを入力してください")
     end
 
     it 'item_idが空だと保存できない' do
       @order.item_id = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("Item can't be blank")
+      expect(@order.errors.full_messages).to include("商品を入力してください")
     end
 
     it 'tokenが空だと保存できない' do
       @order.token = nil
       @order.valid?
-      expect(@order.errors.full_messages).to include("Token can't be blank")
+      expect(@order.errors.full_messages).to include("クレジットカード情報を入力してください")
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -21,28 +21,28 @@ RSpec.describe Item, type: :model do
       @item.image = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Image can't be blank")
-      expect(@item.errors.full_messages).to include("画像を選択してください")
+      expect(@item.errors.full_messages).to include('画像を選択してください')
     end
 
     it 'nameが空だと保存できない' do
       @item.name = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Name can't be blank")
-      expect(@item.errors.full_messages).to include("商品名を入力してください")
+      expect(@item.errors.full_messages).to include('商品名を入力してください')
     end
 
     it 'infoが空だと保存できない' do
       @item.info = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Info can't be blank")
-      expect(@item.errors.full_messages).to include("商品の説明を入力してください")
+      expect(@item.errors.full_messages).to include('商品の説明を入力してください')
     end
 
     it 'categoryが空だと保存できない' do
       @item.category = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Category can't be blank")
-      expect(@item.errors.full_messages).to include("カテゴリーを入力してください")
+      expect(@item.errors.full_messages).to include('カテゴリーを入力してください')
     end
 
     it 'categoryが選択されていないと保存できない' do
@@ -56,7 +56,7 @@ RSpec.describe Item, type: :model do
       @item.sales_status = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Sales status can't be blank")
-      expect(@item.errors.full_messages).to include("商品の状態を入力してください")
+      expect(@item.errors.full_messages).to include('商品の状態を入力してください')
     end
 
     it 'sales_statusが選択されていないと保存できない' do
@@ -70,7 +70,7 @@ RSpec.describe Item, type: :model do
       @item.shipping_fee_status = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Shipping fee status can't be blank")
-      expect(@item.errors.full_messages).to include("配送料の負担を入力してください")
+      expect(@item.errors.full_messages).to include('配送料の負担を入力してください')
     end
 
     it 'shipping_fee_statusが選択されていないと保存できない' do
@@ -84,7 +84,7 @@ RSpec.describe Item, type: :model do
       @item.prefecture = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Prefecture can't be blank")
-      expect(@item.errors.full_messages).to include("発送元の地域を入力してください")
+      expect(@item.errors.full_messages).to include('発送元の地域を入力してください')
     end
 
     it 'prefectureが選択されていないと保存できない' do
@@ -98,7 +98,7 @@ RSpec.describe Item, type: :model do
       @item.scheduled_delivery = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank")
-      expect(@item.errors.full_messages).to include("発送までの日数を入力してください")
+      expect(@item.errors.full_messages).to include('発送までの日数を入力してください')
     end
 
     it 'scheduled_deliveryが選択されていないと保存できない' do
@@ -112,7 +112,7 @@ RSpec.describe Item, type: :model do
       @item.price = nil
       @item.valid?
       # expect(@item.errors.full_messages).to include("Price can't be blank")
-      expect(@item.errors.full_messages).to include("販売価格を入力してください")
+      expect(@item.errors.full_messages).to include('販売価格を入力してください')
     end
 
     it 'priceを半角数字で入力しないと保存できない' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,109 +13,127 @@ RSpec.describe Item, type: :model do
     it 'userが紐づいていないと保存できない' do
       @item.user = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include('User must exist')
+      # expect(@item.errors.full_messages).to include('User must exist')
+      expect(@item.errors.full_messages).to include('ユーザーを入力してください')
     end
 
     it 'imageが空だと保存できない' do
       @item.image = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
+      # expect(@item.errors.full_messages).to include("Image can't be blank")
+      expect(@item.errors.full_messages).to include("画像を選択してください")
     end
 
     it 'nameが空だと保存できない' do
       @item.name = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
+      # expect(@item.errors.full_messages).to include("Name can't be blank")
+      expect(@item.errors.full_messages).to include("商品名を入力してください")
     end
 
     it 'infoが空だと保存できない' do
       @item.info = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Info can't be blank")
+      # expect(@item.errors.full_messages).to include("Info can't be blank")
+      expect(@item.errors.full_messages).to include("商品の説明を入力してください")
     end
 
     it 'categoryが空だと保存できない' do
       @item.category = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Category can't be blank")
+      # expect(@item.errors.full_messages).to include("Category can't be blank")
+      expect(@item.errors.full_messages).to include("カテゴリーを入力してください")
     end
 
     it 'categoryが選択されていないと保存できない' do
       @item.category_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Category Select')
+      # expect(@item.errors.full_messages).to include('Category Select')
+      expect(@item.errors.full_messages).to include('カテゴリーを選択してください')
     end
 
     it 'sales_statusが空だと保存できない' do
       @item.sales_status = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Sales status can't be blank")
+      # expect(@item.errors.full_messages).to include("Sales status can't be blank")
+      expect(@item.errors.full_messages).to include("商品の状態を入力してください")
     end
 
     it 'sales_statusが選択されていないと保存できない' do
       @item.sales_status_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Sales status Select')
+      # expect(@item.errors.full_messages).to include('Sales status Select')
+      expect(@item.errors.full_messages).to include('商品の状態を選択してください')
     end
 
     it 'shipping_fee_statusが空だと保存できない' do
       @item.shipping_fee_status = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping fee status can't be blank")
+      # expect(@item.errors.full_messages).to include("Shipping fee status can't be blank")
+      expect(@item.errors.full_messages).to include("配送料の負担を入力してください")
     end
 
     it 'shipping_fee_statusが選択されていないと保存できない' do
       @item.shipping_fee_status_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Shipping fee status Select')
+      # expect(@item.errors.full_messages).to include('Shipping fee status Select')
+      expect(@item.errors.full_messages).to include('配送料の負担を選択してください')
     end
 
     it 'prefectureが空だと保存できない' do
       @item.prefecture = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+      # expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+      expect(@item.errors.full_messages).to include("発送元の地域を入力してください")
     end
 
     it 'prefectureが選択されていないと保存できない' do
       @item.prefecture_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Prefecture Select')
+      # expect(@item.errors.full_messages).to include('Prefecture Select')
+      expect(@item.errors.full_messages).to include('発送元の地域を選択してください')
     end
 
     it 'scheduled_deliveryが空だと保存できない' do
       @item.scheduled_delivery = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank")
+      # expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank")
+      expect(@item.errors.full_messages).to include("発送までの日数を入力してください")
     end
 
     it 'scheduled_deliveryが選択されていないと保存できない' do
       @item.scheduled_delivery_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Scheduled delivery Select')
+      # expect(@item.errors.full_messages).to include('Scheduled delivery Select')
+      expect(@item.errors.full_messages).to include('発送までの日数を選択してください')
     end
 
     it 'priceが空だと保存できない' do
       @item.price = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price can't be blank")
+      # expect(@item.errors.full_messages).to include("Price can't be blank")
+      expect(@item.errors.full_messages).to include("販売価格を入力してください")
     end
 
     it 'priceを半角数字で入力しないと保存できない' do
       @item.price = 'number'
       @item.valid?
-      expect(@item.errors.full_messages).to include('Price must be Half-width number')
+      # expect(@item.errors.full_messages).to include('Price must be Half-width number')
+      expect(@item.errors.full_messages).to include('販売価格は半角数字で入力してください')
     end
 
     it 'priceが300未満の場合は保存できない' do
       @item.price = 299
       @item.valid?
-      expect(@item.errors.full_messages).to include('Price is Out of setting range')
+      # expect(@item.errors.full_messages).to include('Price is Out of setting range')
+      expect(@item.errors.full_messages).to include('販売価格は ¥300〜¥9,999,999の間に設定してください')
     end
 
     it 'priceが10,000,000以上の場合は保存できない' do
       @item.price = 10_000_000
       @item.valid?
-      expect(@item.errors.full_messages).to include('Price is Out of setting range')
+      # expect(@item.errors.full_messages).to include('Price is Out of setting range')
+      expect(@item.errors.full_messages).to include('販売価格は ¥300〜¥9,999,999の間に設定してください')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe User, type: :model do
       @user.email = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Email can't be blank")
-      expect(@user.errors.full_messages).to include("Eメールを入力してください")
+      expect(@user.errors.full_messages).to include("メールアドレスを入力してください")
     end
 
     it 'emailに@がないと保存できない' do
       @user.email = 'aaa'
       @user.valid?
       # expect(@user.errors.full_messages).to include('Email is invalid')
-      expect(@user.errors.full_messages).to include('Eメールは不正な値です')
+      expect(@user.errors.full_messages).to include('メールアドレスは不正な値です')
     end
 
     it 'emailが重複していると保存できない' do
@@ -37,7 +37,7 @@ RSpec.describe User, type: :model do
       @user.save
       another_user.valid?
       # expect(another_user.errors.full_messages).to include('Email has already been taken')
-      expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
+      expect(another_user.errors.full_messages).to include('メールアドレスはすでに存在します')
     end
 
     it 'passwordが空だと保存できない' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe User, type: :model do
       @user.nickname = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Nickname can't be blank")
-      expect(@user.errors.full_messages).to include("ニックネームを入力してください")
+      expect(@user.errors.full_messages).to include('ニックネームを入力してください')
     end
 
     it 'emailが空だと保存できない' do
       @user.email = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Email can't be blank")
-      expect(@user.errors.full_messages).to include("メールアドレスを入力してください")
+      expect(@user.errors.full_messages).to include('メールアドレスを入力してください')
     end
 
     it 'emailに@がないと保存できない' do
@@ -45,7 +45,7 @@ RSpec.describe User, type: :model do
       @user.password_confirmation = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Password can't be blank")
-      expect(@user.errors.full_messages).to include("パスワードを入力してください")
+      expect(@user.errors.full_messages).to include('パスワードを入力してください')
     end
 
     it 'passwordが5文字以下だと保存できない' do
@@ -76,7 +76,7 @@ RSpec.describe User, type: :model do
       @user.password_confirmation = ''
       @user.valid?
       # expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
+      expect(@user.errors.full_messages).to include('パスワード（確認用）とパスワードの入力が一致しません')
     end
 
     it 'passwordとpassword_confirmationの値が異なると保存できない' do
@@ -84,14 +84,14 @@ RSpec.describe User, type: :model do
       @user.password_confirmation = '789xyz'
       @user.valid?
       # expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
+      expect(@user.errors.full_messages).to include('パスワード（確認用）とパスワードの入力が一致しません')
     end
 
     it '本名（名字）が空だと保存できない' do
       @user.last_name = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Last name can't be blank")
-      expect(@user.errors.full_messages).to include("名字を入力してください")
+      expect(@user.errors.full_messages).to include('名字を入力してください')
     end
 
     it '本名（名字）は全角で入力しないと保存できない' do
@@ -105,7 +105,7 @@ RSpec.describe User, type: :model do
       @user.first_name = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("First name can't be blank")
-      expect(@user.errors.full_messages).to include("名前を入力してください")
+      expect(@user.errors.full_messages).to include('名前を入力してください')
     end
 
     it '本名（名前）は全角で入力しないと保存できない' do
@@ -119,7 +119,7 @@ RSpec.describe User, type: :model do
       @user.last_name_kana = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Last name kana can't be blank")
-      expect(@user.errors.full_messages).to include("名字（カナ）を入力してください")
+      expect(@user.errors.full_messages).to include('名字（カナ）を入力してください')
     end
 
     it '本名（名字フリガナ）は全角（カナ）で入力しないと保存できない' do
@@ -133,7 +133,7 @@ RSpec.describe User, type: :model do
       @user.first_name_kana = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("First name kana can't be blank")
-      expect(@user.errors.full_messages).to include("名前（カナ）を入力してください")
+      expect(@user.errors.full_messages).to include('名前（カナ）を入力してください')
     end
 
     it '本名（名前フリガナ）は全角（カナ）で入力しないと保存できない' do
@@ -147,7 +147,7 @@ RSpec.describe User, type: :model do
       @user.birth_date = nil
       @user.valid?
       # expect(@user.errors.full_messages).to include("Birth date can't be blank")
-      expect(@user.errors.full_messages).to include("生年月日を入力してください")
+      expect(@user.errors.full_messages).to include('生年月日を入力してください')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,19 +13,22 @@ RSpec.describe User, type: :model do
     it 'nicknameが空だと保存できない' do
       @user.nickname = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      # expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      expect(@user.errors.full_messages).to include("ニックネームを入力してください")
     end
 
     it 'emailが空だと保存できない' do
       @user.email = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Email can't be blank")
+      # expect(@user.errors.full_messages).to include("Email can't be blank")
+      expect(@user.errors.full_messages).to include("Eメールを入力してください")
     end
 
     it 'emailに@がないと保存できない' do
       @user.email = 'aaa'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Email is invalid')
+      # expect(@user.errors.full_messages).to include('Email is invalid')
+      expect(@user.errors.full_messages).to include('Eメールは不正な値です')
     end
 
     it 'emailが重複していると保存できない' do
@@ -33,102 +36,118 @@ RSpec.describe User, type: :model do
       another_user.email = @user.email
       @user.save
       another_user.valid?
-      expect(another_user.errors.full_messages).to include('Email has already been taken')
+      # expect(another_user.errors.full_messages).to include('Email has already been taken')
+      expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
     end
 
     it 'passwordが空だと保存できない' do
       @user.password = nil
       @user.password_confirmation = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password can't be blank")
+      # expect(@user.errors.full_messages).to include("Password can't be blank")
+      expect(@user.errors.full_messages).to include("パスワードを入力してください")
     end
 
     it 'passwordが5文字以下だと保存できない' do
       @user.password = '123ab'
       @user.password_confirmation = '123ab'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+      # expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+      expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
     end
 
     it 'passwordが半角数字のみの場合、保存できない' do
       @user.password = '123456'
       @user.password_confirmation = '123456'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Password is invalid')
+      # expect(@user.errors.full_messages).to include('Password is invalid')
+      expect(@user.errors.full_messages).to include('パスワードは英数字混合で入力してください')
     end
 
     it 'passwordが半角英字のみの場合、保存できない' do
       @user.password = 'abcdef'
       @user.password_confirmation = 'abcdef'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Password is invalid')
+      # expect(@user.errors.full_messages).to include('Password is invalid')
+      expect(@user.errors.full_messages).to include('パスワードは英数字混合で入力してください')
     end
 
     it 'passwordに値があってもpassword_confirmationが空だと保存できない' do
       @user.password_confirmation = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      # expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
     end
 
     it 'passwordとpassword_confirmationの値が異なると保存できない' do
       @user.password = '123abc'
       @user.password_confirmation = '789xyz'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      # expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
     end
 
     it '本名（名字）が空だと保存できない' do
       @user.last_name = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Last name can't be blank")
+      # expect(@user.errors.full_messages).to include("Last name can't be blank")
+      expect(@user.errors.full_messages).to include("名字を入力してください")
     end
 
     it '本名（名字）は全角で入力しないと保存できない' do
       @user.last_name = 'saito'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Last name is invalid')
+      # expect(@user.errors.full_messages).to include('Last name is invalid')
+      expect(@user.errors.full_messages).to include('名字は全角で入力してください')
     end
 
     it '本名（名前）が空だと保存できない' do
       @user.first_name = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name can't be blank")
+      # expect(@user.errors.full_messages).to include("First name can't be blank")
+      expect(@user.errors.full_messages).to include("名前を入力してください")
     end
 
     it '本名（名前）は全角で入力しないと保存できない' do
       @user.first_name = 'keisuke'
       @user.valid?
-      expect(@user.errors.full_messages).to include('First name is invalid')
+      # expect(@user.errors.full_messages).to include('First name is invalid')
+      expect(@user.errors.full_messages).to include('名前は全角で入力してください')
     end
 
     it '本名（名字フリガナ）が空だと保存できない' do
       @user.last_name_kana = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+      # expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+      expect(@user.errors.full_messages).to include("名字（カナ）を入力してください")
     end
 
     it '本名（名字フリガナ）は全角（カナ）で入力しないと保存できない' do
       @user.last_name_kana = 'さいとう'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Last name kana is invalid')
+      # expect(@user.errors.full_messages).to include('Last name kana is invalid')
+      expect(@user.errors.full_messages).to include('名字（カナ）は全角（カナ）で入力してください')
     end
 
     it '本名（名前フリガナ）が空だと保存できない' do
       @user.first_name_kana = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana can't be blank")
+      # expect(@user.errors.full_messages).to include("First name kana can't be blank")
+      expect(@user.errors.full_messages).to include("名前（カナ）を入力してください")
     end
 
     it '本名（名前フリガナ）は全角（カナ）で入力しないと保存できない' do
       @user.first_name_kana = 'けいすけ'
       @user.valid?
-      expect(@user.errors.full_messages).to include('First name kana is invalid')
+      # expect(@user.errors.full_messages).to include('First name kana is invalid')
+      expect(@user.errors.full_messages).to include('名前（カナ）は全角（カナ）で入力してください')
     end
 
     it '生年月日が空だと保存できない' do
       @user.birth_date = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Birth date can't be blank")
+      # expect(@user.errors.full_messages).to include("Birth date can't be blank")
+      expect(@user.errors.full_messages).to include("生年月日を入力してください")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,8 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
-# テストコードを英語化
-I18n.locale = 'en'
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
# Why
- ユーザーがより正しく情報を入力できるようにするため

# What
- アプリケーションでの使用言語を日本語へ変更
- gem rails-i18n を導入
- config/locale ディレクトリ内に、devise.ja.yml および ja.yml を作成
- 日本語翻訳を自然な形に修正

## 動作確認
### Userモデル
- 新規登録 : https://gyazo.com/bf7d002589a3e9ccb44165c51f0e623a
- ログイン : https://gyazo.com/fe8495e078b7ef4901f65887f21c538d
- ログイン (ログアウト後) : https://gyazo.com/add9a2612e0bae8973060a22abc34759
- モデル単体テスト : https://gyazo.com/818431ca11500cccb0a9203252bdbdb5

### Itemモデル
- 新規投稿 : https://gyazo.com/9d49286e499e64b13f1ca06dc0029f3b
- 編集 (画面は一部) : https://gyazo.com/b3dbbf378252a8eaf6c51b85ee20b2ee
- モデル単体テスト : https://gyazo.com/be9e3d1f27fc152c27f001383b30f940

### Commentモデル
- モデル単体テスト : https://gyazo.com/ecdd31809c32b6ebbef0408141b6c5e7

### ItemOrder (Formオブジェクト)
- 購入 : https://gyazo.com/efe9e68708c115cee3daf1bc76688aa9
- モデル単体テスト : https://gyazo.com/61a9cb45dd698bab54ce23fba88984fd