### PR TITLE
開発環境の画像保存先をローカルストレージに変更

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
# Why
- AWS S3 のGETリクエストが多かったため、開発環境での画像保存先は、いったんローカルに変更したい

# What
- 開発環境のYAMLファイルで、ストレージをlocal変更