### PR TITLE
コメント一覧表示にsimple_formatを使用

### DIFF
--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -237,6 +237,7 @@ summary {
   background-color: whitesmoke;
   margin: 10px 0px;
   padding: 10px;
+  text-align: left;
 }
 
 .comment-info {
@@ -250,8 +251,4 @@ summary {
   margin-right: 5px;
   padding-right: 5px;
   border-right: 1px solid gray;
-}
-
-.comment-text {
-  text-align: left;
 }

--- a/app/views/shared/_comment.html.erb
+++ b/app/views/shared/_comment.html.erb
@@ -3,5 +3,5 @@
     <p class="comment-user"><%= comment.user.nickname %></p>
     <p class="comment-time"><%= l comment.created_at %></p>
   </div>
-  <p class="comment-text"><%= comment.text %></p>
+  <p><%= simple_format(comment.text) %></p>
 </div>


### PR DESCRIPTION
# Why
- 現状、コメントフォームで改行を入れて送信しても、コメント一覧に改行が反映されないため

# What
- simple_format を用いてコメントを出力

## 機能確認
- https://gyazo.com/2f2e1d7295a8ddc6107603fbb5b6f026

Closes #21 